### PR TITLE
Same issue as UnitId2String

### DIFF
--- a/common.j
+++ b/common.j
@@ -930,6 +930,7 @@ constant native OrderId                     takes string  orderIdString     retu
 
 /**
 @pure
+@bug Always returns null after the game is loaded/if the game is a replay.
 @bug Do not use this in a global initialisation as it returns null there.
 */
 constant native OrderId2String              takes integer orderId           returns string


### PR DESCRIPTION
See https://www.hiveworkshop.com/threads/orderid2string-returns-null-after-loading-a-saved-game.336367/#post-3507470