### PR TITLE
gamespeed: describe mechanics of base game speed

### DIFF
--- a/common.j
+++ b/common.j
@@ -64,7 +64,9 @@ Warcraft 3 game speed setting:
 | Medium         | `MAP_SPEED_SLOW`   | 0.8x  | 12.5s         |
 | Slow           | `MAP_SPEED_SLOWEST`| 0.6x  | 16.667s       |
 
-Note that this setting is actually just a multiplier for a "base game speed",
+
+@note
+This setting is actually just a multiplier for a "base game speed",
 which is normally set to 1.0x (100%).
 
 You can achieve a higher "base game speed" via a .wgc file only for testing.
@@ -82,6 +84,11 @@ are shown in the table below:
 |              3x |              0.6x |           1.80x |
 |              3x |              0.8x |           2.40x |
 |              3x |              1.0x |           3.00x |
+
+Further reading:
+
+- [How to run maps with high gamespeed](https://www.hiveworkshop.com/threads/how-to-run-maps-with-high-gamespeed.37255/)
+- [WGC file format specification](https://github.com/ChiefOfGxBxL/WC3MapSpecification/pull/4)
 
 @bug (v1.27, v1.32.10 tested) Restarting the map from the F10 in-game menu
 will reset the "base game speed" back to 1x.
@@ -1305,10 +1312,27 @@ globals
     constant gamedifficulty     MAP_DIFFICULTY_HARD                 = ConvertGameDifficulty(2)
     constant gamedifficulty     MAP_DIFFICULTY_INSANE               = ConvertGameDifficulty(3)
 
+/**
+@note See `gamespeed` for explanation, values and mechanics.
+*/
     constant gamespeed          MAP_SPEED_SLOWEST                   = ConvertGameSpeed(0)
+/**
+@note See `gamespeed` for explanation, values and mechanics.
+*/
     constant gamespeed          MAP_SPEED_SLOW                      = ConvertGameSpeed(1)
+/**
+@note See `gamespeed` for explanation, values and mechanics.
+*/
     constant gamespeed          MAP_SPEED_NORMAL                    = ConvertGameSpeed(2)
+/**
+@note See `gamespeed` for explanation, values and mechanics.
+@bug Currently unused, resets to `MAP_SPEED_NORMAL`.
+*/
     constant gamespeed          MAP_SPEED_FAST                      = ConvertGameSpeed(3)
+/**
+@note See `gamespeed` for explanation, values and mechanics.
+@bug Currently unused, resets to `MAP_SPEED_NORMAL`.
+*/
     constant gamespeed          MAP_SPEED_FASTEST                   = ConvertGameSpeed(4)
 
     constant playerslotstate    PLAYER_SLOT_STATE_EMPTY             = ConvertPlayerSlotState(0)

--- a/common.j
+++ b/common.j
@@ -64,6 +64,28 @@ Warcraft 3 game speed setting:
 | Medium         | `MAP_SPEED_SLOW`   | 0.8x  | 12.5s         |
 | Slow           | `MAP_SPEED_SLOWEST`| 0.6x  | 16.667s       |
 
+Note that this setting is actually just a multiplier for a "base game speed",
+which is normally set to 1.0x (100%).
+
+You can achieve a higher "base game speed" via a .wgc file only for testing.
+The in-game `gamespeed` is actually a multiplier on top of that. The results
+are shown in the table below:
+
+| Base game speed | Game speed option | Effective speed |
+| --------------: | ----------------: | --------------: |
+|              1x |              0.6x |           0.60x |
+|              1x |              0.8x |           0.80x |
+|              1x |              1.0x |           1.00x |
+|              2x |              0.6x |           1.20x |
+|              2x |              0.8x |           1.60x |
+|              2x |              1.0x |           2.00x |
+|              3x |              0.6x |           1.80x |
+|              3x |              0.8x |           2.40x |
+|              3x |              1.0x |           3.00x |
+
+@bug (v1.27, v1.32.10 tested) Restarting the map from the F10 in-game menu
+will reset the "base game speed" back to 1x.
+
 */
 type gamespeed          extends     handle
 

--- a/map-setup.j
+++ b/map-setup.j
@@ -86,6 +86,14 @@ native SetMapFlag takes mapflag whichMapFlag, boolean value returns nothing
 
 native SetGamePlacement takes placement whichPlacementType returns nothing
 
+/**
+Sets a new gamespeed to run the map at.
+
+@param whichspeed The gamespeed constant to be set as new speed.
+The only allowed values are: `MAP_SPEED_SLOWEST`, `MAP_SPEED_SLOW` and `MAP_SPEED_NORMAL`, because `MAP_SPEED_FAST` and `MAP_SPEED_FASTEST` are automatically reverted to normal speed.
+
+@note See: `SetGameSpeed`, and for values and mechanics: `gamespeed`.
+*/
 native SetGameSpeed takes gamespeed whichspeed returns nothing
 
 native SetGameDifficulty takes gamedifficulty whichdifficulty returns nothing
@@ -112,6 +120,11 @@ native IsMapFlagSet takes mapflag whichMapFlag returns boolean
 
 constant native GetGamePlacement takes nothing returns placement
 
+/**
+Returns the currently set gamespeed.
+
+@note See: `SetGameSpeed` and for values and mechanics `gamespeed`.
+*/
 constant native GetGameSpeed takes nothing returns gamespeed
 
 constant native GetGameDifficulty takes nothing returns gamedifficulty


### PR DESCRIPTION
Base game speed can only be set via a .wgc file (Warcraft 3 Game
Configuration) that you can trigger by testing your map from within the
AI editor.

As always doing avantgarde work on a 20yo game :)

PS: Tool coming soon to automate creation of a .wgc file and launch the game with it. The WE seems totally broken for this with Refunded.

Explanation of .wcg testing: https://www.hiveworkshop.com/threads/how-to-run-maps-with-high-gamespeed.37255/

.wcg format will be sent as a PR there: https://github.com/ChiefOfGxBxL/WC3MapSpecification