### PR TITLE
Add execution frequency table for TimerStart and TriggerRegisterTimerEvent

### DIFF
--- a/Blizzard.j
+++ b/Blizzard.j
@@ -954,6 +954,22 @@ endfunction
 // trigger is not interrupted as is the case with a TriggerExecute call.
 // Since the trigger executes normally, its conditions are still evaluated.
 //
+/**
+Adds trigger to execution queue by setting it up with a zero-delay timer,
+so it is executed almost immediately. Unlike calling another trigger with
+`TriggerExecute`, this does not interrupt the currently running trigger.
+
+@param trig Target trigger to execute
+@param checkConditions
+If `true`, check if trigger conditions are met and only then queue the trigger.
+If `false`, ignores conditions and always queues the trigger.
+
+Returns:
+
+- `true`, if trigger will be executed
+- `false`, if conditions were not met
+
+*/
 function PostTriggerExecuteBJ takes trigger trig, boolean checkConditions returns boolean
     if checkConditions then
         if not (TriggerEvaluate(trig)) then

--- a/game-event-api.j
+++ b/game-event-api.j
@@ -10,7 +10,28 @@ native TriggerRegisterVariableEvent takes trigger whichTrigger, string varName, 
 
 
 /**
-Creates it's own timer and triggers when it expires
+Creates its own timer and triggers when it expires.
+
+@note The table below shows how often `TriggerRegisterTimerEvent` aka 
+`TriggerRegisterTimerEventPeriodic` is executed per second with different
+timeout values set.
+This is in comparison with a 1ms and 0ms `timer`.
+
+Note how its frequency was limited to 100 times per second in v1.32.x.
+
+| Trigger or Timer \ Tick count  |   ROC 1.0 | Reforged 1.32.10 |
+|--------------------------------|----------:|-----------------:|
+| 1000ms Trigger periodic        |      1 Hz |             1 Hz |
+| 100ms Trigger periodic         |     10 Hz |            10 Hz |
+| 20ms Trigger periodic          |     50 Hz |            50 Hz |
+| 10ms Trigger periodic          |    100 Hz |           100 Hz |
+| 5ms Trigger periodic           |    200 Hz |           100 Hz |
+| 1ms Trigger periodic           |   1000 Hz |           100 Hz |
+| 0ms Trigger periodic           |  10077 Hz |           100 Hz |
+| 1ms Timer                      |   1000 Hz |          1000 Hz |
+| 0ms Timer                      |  10077 Hz |         10077 Hz |
+
+See: `TimerStart`
 */
 native TriggerRegisterTimerEvent takes trigger whichTrigger, real timeout, boolean periodic returns event
 

--- a/timer.j
+++ b/timer.j
@@ -9,6 +9,25 @@ then callback is called with `GetElapsedTimer` being `null`.
 */
 native DestroyTimer         takes timer whichTimer returns nothing
 
+/**
+TODO description
+
+@note The table below shows how often a 0 millisecond timer is executed
+in comparison with `TriggerRegisterTimerEvent`
+(aka `TriggerRegisterTimerEventPeriodic`).
+
+| Trigger or Timer \ Tick count  |   ROC 1.0 | Reforged 1.32.10 |
+|--------------------------------|----------:|-----------------:|
+| 1000ms Trigger periodic        |      1 Hz |             1 Hz |
+| 100ms Trigger periodic         |     10 Hz |            10 Hz |
+| 20ms Trigger periodic          |     50 Hz |            50 Hz |
+| 10ms Trigger periodic          |    100 Hz |           100 Hz |
+| 5ms Trigger periodic           |    200 Hz |           100 Hz |
+| 1ms Trigger periodic           |   1000 Hz |           100 Hz |
+| 0ms Trigger periodic           |  10077 Hz |           100 Hz |
+| 1ms Timer                      |   1000 Hz |          1000 Hz |
+| 0ms Timer                      |  10077 Hz |         10077 Hz |
+*/
 native TimerStart           takes timer whichTimer, real timeout, boolean periodic, code handlerFunc returns nothing
 
 /**

--- a/trigger.j
+++ b/trigger.j
@@ -92,8 +92,8 @@ native TriggerWaitForSound  takes sound s, real offset returns nothing
 Evaluates all functions that were added to the trigger via `TriggerAddCondition`.
 All return-values from all added condition-functions are `and`ed together as the final return-value.
 Returns the boolean value of the return value from the condition-function.
-So if `0`/`0.0`/`null` would be returned in the condition-function, `TriggerEvaluate`
-would return `false`. Note that `""` would return `true`.
+So if the condition-functions return `0`/`0.0`/`null`, then `TriggerEvaluate`
+will return `false`. Note that an empty string `""` would return `true`.
 
 @note If a condition-function crashes the thread or does not return any value
 `TriggerEvaluate` will return `false`.


### PR DESCRIPTION
I do not have time and motivation to describe these two in-depth, but I wanted to add the table lest I forget it (and I was asked by Codemonkey too)

Is this OK? (eyes looking at #45 :eyes: )

Source:
https://www.hiveworkshop.com/threads/high-speed-triggers-or-a-slow-triggerregistertimereventperiodic.341024/