### PR TITLE
Document Fog of War API

### DIFF
--- a/common.j
+++ b/common.j
@@ -132,6 +132,21 @@ type effect             extends     agent
 type effecttype         extends     handle
 type weathereffect      extends     handle
 type terraindeformation extends     handle
+
+/**
+Represents different fog of war types.
+
+- `FOG_OF_WAR_MASKED` (1): Black mask, an unexplored map area.
+   - If "Masked areas are partially visible" is enabled in
+Map Properties, unexplored areas are shown in dark grey.
+You can see the terrain, but no units.
+   - If disabled, unexplored areas are black and not visible.
+- `FOG_OF_WAR_FOGGED` (2): Haze, a previously explored
+map area that is currently not visible.
+   - You can see the terrain, but no units.
+- `FOG_OF_WAR_VISIBLE` (4): A fully visible map area.
+- Other (non-existent) fog types do nothing.
+*/
 type fogstate           extends     handle
 type fogmodifier        extends     agent
 type dialog             extends     agent
@@ -848,6 +863,8 @@ constant native ConvertSubAnimType          takes integer i returns subanimtype
 
 
 /**
+Converts a bitmask in integer i to a fog of war type. See: `fogstate`.
+
 @note Can be used for extended typecasting.
 <http://www.hiveworkshop.com/forums/j-280/t-232039/>
 @pure
@@ -1975,8 +1992,17 @@ TriggerRegisterGameEvent(trg_gameev, EVENT_GAME_BUILD_SUBMENU)
     constant texmapflags    TEXMAP_FLAG_WRAP_V              = ConvertTexMapFlags(2)
     constant texmapflags    TEXMAP_FLAG_WRAP_UV             = ConvertTexMapFlags(3)
 
+/**
+See `fogstate` for an explanation.
+*/
     constant fogstate       FOG_OF_WAR_MASKED               = ConvertFogState(1)
+/**
+See `fogstate` for an explanation.
+*/
     constant fogstate       FOG_OF_WAR_FOGGED               = ConvertFogState(2)
+/**
+See `fogstate` for an explanation.
+*/
     constant fogstate       FOG_OF_WAR_VISIBLE              = ConvertFogState(4)
 
 //===================================================

--- a/common.j
+++ b/common.j
@@ -137,13 +137,13 @@ type terraindeformation extends     handle
 Represents different fog of war types.
 
 - `FOG_OF_WAR_MASKED` (1): Black mask, an unexplored map area.
-   - If "Masked areas are partially visible" is enabled in
+    - If "Masked areas are partially visible" is enabled in
 Map Properties, unexplored areas are shown in dark grey.
 You can see the terrain, but no units.
-   - If disabled, unexplored areas are black and not visible.
+    - If disabled, unexplored areas are black and not visible.
 - `FOG_OF_WAR_FOGGED` (2): Haze, a previously explored
 map area that is currently not visible.
-   - You can see the terrain, but no units.
+    - You can see the terrain, but no units.
 - `FOG_OF_WAR_VISIBLE` (4): A fully visible map area.
 - Other (non-existent) fog types do nothing.
 */

--- a/fog-of-war.j
+++ b/fog-of-war.j
@@ -9,7 +9,7 @@ which areas were explored or still hidden; which are fogged (not visible); which
 visible. What is visible in game is a combination of personal fog state & fog modifiers.
 
 @param forWhichPlayer Target player.
-@param whichState Change fog to this type.
+@param whichState Change fog to this type. See `fogstate` for type explanation.
 @param where Target rectangle area
 @param useSharedVision
 If true, apply new state to player and whoever player shares their vision.
@@ -26,7 +26,7 @@ which areas were explored or still hidden; which are fogged (not visible); which
 visible. What is visible in game is a combination of personal fog state & fog modifiers.
 
 @param forWhichPlayer Target player.
-@param whichState Change fog to this type.
+@param whichState Change fog to this type. See `fogstate` for type explanation.
 @param centerx X-coordinate of the circle center.
 @param centery Y-coordinate of the circle center.
 @param radius Circle's radius (from center to its edge)
@@ -44,7 +44,7 @@ which areas were explored or still hidden; which are fogged (not visible); which
 visible. What is visible in game is a combination of personal fog state & fog modifiers.
 
 @param forWhichPlayer Target player.
-@param whichState Change fog to this type.
+@param whichState Change fog to this type. See `fogstate` for type explanation.
 @param center Location describing the center of the circle.
 @param radius Circle's radius (from center to its edge)
 @param useSharedVision
@@ -117,7 +117,7 @@ A fog modifier is disabled by default, use `FogModifierStart` to enable.
 This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
 @param whichState
-Determines what type of fog the area is being modified to.
+Determines what type of fog the area is being modified to. See `fogstate` for type explanation.
 
 @param where The rect where the fog is
 
@@ -143,7 +143,7 @@ A fog modifier is disabled by default, use `FogModifierStart` to enable.
 This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
 @param whichState
-Determines what type of fog the area is being modified to.
+Determines what type of fog the area is being modified to. See `fogstate` for type explanation.
 
 @param centerx
 The x-coordinate where the fog modifier begins.
@@ -158,7 +158,7 @@ Determines the extent that the fog travels (expanding from the coordinates ( cen
 Apply modifier to target's allied players with shared vision?
 
 @param afterUnits
-Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
+Will determine whether or not units in that area will be masked by the fog. If it is set to true and the `fogstate` is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
 
 @bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
 `FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
@@ -176,7 +176,7 @@ A fog modifier is disabled by default, use `FogModifierStart` to enable.
 This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
 @param whichState
-Determines what type of fog the area is being modified to.
+Determines what type of fog the area is being modified to. See `fogstate` for type explanation.
 
 @param center
 The location where the fog modifier begins.
@@ -188,7 +188,7 @@ Determines the extent that the fog travels (expanding from the location `center`
 Apply modifier to target's allied players with shared vision?
 
 @param afterUnits
-Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
+Will determine whether or not units in that area will be masked by the fog. If it is set to true and the `fogstate` is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
 
 @bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
 `FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is

--- a/fog-of-war.j
+++ b/fog-of-war.j
@@ -4,8 +4,9 @@
 /**
 Sets target player's fog of war data in the specified rectangle.
 
-The fog state is a reflection of what the player currently sees in game
-and on the minimap.
+Individual player's fog state is a reflection of player's map exploration progress:
+which areas were explored or still hidden; which are fogged (not visible); which are
+visible. What is visible in game is a combination of personal fog state & fog modifiers.
 
 @param forWhichPlayer Target player.
 @param whichState Change fog to this type.
@@ -20,8 +21,9 @@ native SetFogStateRect takes player forWhichPlayer, fogstate whichState, rect wh
 /**
 Sets target player's fog of war data in the specified circle area.
 
-The fog state is a reflection of what the player currently sees in game
-and on the minimap.
+Individual player's fog state is a reflection of player's map exploration progress:
+which areas were explored or still hidden; which are fogged (not visible); which are
+visible. What is visible in game is a combination of personal fog state & fog modifiers.
 
 @param forWhichPlayer Target player.
 @param whichState Change fog to this type.
@@ -37,8 +39,9 @@ native SetFogStateRadius takes player forWhichPlayer, fogstate whichState, real 
 /**
 Sets target player's fog of war data in the specified circle area.
 
-The fog state is a reflection of what the player currently sees in game
-and on the minimap.
+Individual player's fog state is a reflection of player's map exploration progress:
+which areas were explored or still hidden; which are fogged (not visible); which are
+visible. What is visible in game is a combination of personal fog state & fog modifiers.
 
 @param forWhichPlayer Target player.
 @param whichState Change fog to this type.
@@ -62,7 +65,7 @@ True: unexplored areas are masked.
 
 False: unexplored areas are not masked (whether visible depends on `IsFogEnabled`).
 
-@note See: `IsFogMaskEnabled`, `FogEnable`
+@note See: `IsFogMaskEnabled`, `IsFogEnabled`. "Fog mask" is explained in `fogstate`.
 */
 native FogMaskEnable takes boolean enable returns nothing
 
@@ -73,6 +76,8 @@ Returns whether global FOW masking is in effect.
 True: unexplored areas are globally masked.
 
 False: unexplored areas are not globally masked (whether visible depends on `IsFogEnabled`).
+
+@note See: `FogMaskEnable`, `FogEnable`. "Fog mask" is explained in `fogstate`.
 */
 native IsFogMaskEnabled takes nothing returns boolean
 
@@ -86,6 +91,8 @@ reversible.
 True: explored areas are fogged if not in sight.
 
 False: explored areas remain permanently visible.
+
+@note See: `IsFogEnabled`, `IsFogMaskEnabled`. "Fog" is explained in `fogstate`.
 */
 native FogEnable takes boolean enable returns nothing
 
@@ -96,12 +103,16 @@ Toggles global FOW fogging of explored yet not visible areas.
 True: explored areas are fogged if not in sight.
 
 False: explored areas remain permanently visible.
+
+@note See: `FogEnable`, `FogMaskEnable`. "Fog" is explained in `fogstate`.
 */
 native IsFogEnabled takes nothing returns boolean
 
 
 /**
 Creates an object that overrides the fog in a rect for a specific player.
+
+A fog modifier is disabled by default, use `FogModifierStart` to enable.
 
 This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
@@ -119,13 +130,15 @@ Will determine whether or not units in that area will be masked by the fog. If i
 @bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
 `FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
 enabled. "VISIBLE" will instantly become "FOGGED" and "FOGGED" will cause unexplored
-areas to become explored. You must workaround this by using e.g. `SetFogStateRect`
+areas to become explored. You can workaround this by using e.g. `SetFogStateRect`
 after fog modifier creation.
 */
 native CreateFogModifierRect takes player forWhichPlayer, fogstate whichState, rect where, boolean useSharedVision, boolean afterUnits returns fogmodifier
 
 /**
 Creates an object that overrides the fog in a circular radius for a specific player.
+
+A fog modifier is disabled by default, use `FogModifierStart` to enable.
 
 This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
@@ -147,18 +160,18 @@ Apply modifier to target's allied players with shared vision?
 @param afterUnits
 Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
 
-@note You must use `FogModifierStart` to enable the fog modifier. 
-
 @bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
 `FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
 enabled. "VISIBLE" will instantly become "FOGGED" and "FOGGED" will cause unexplored
-areas to become explored. You must workaround this by using e.g. `SetFogStateRect`
+areas to become explored. You can workaround this by using e.g. `SetFogStateRect`
 after fog modifier creation.
 */
 native CreateFogModifierRadius takes player forWhichPlayer, fogstate whichState, real centerx, real centerY, real radius, boolean useSharedVision, boolean afterUnits returns fogmodifier
 
 /**
 Creates an object that overrides the fog in a circular radius for a specific player.
+
+A fog modifier is disabled by default, use `FogModifierStart` to enable.
 
 This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
@@ -177,12 +190,10 @@ Apply modifier to target's allied players with shared vision?
 @param afterUnits
 Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
 
-@note You must use `FogModifierStart` to enable the fog modifier. 
-
 @bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
 `FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
 enabled. "VISIBLE" will instantly become "FOGGED" and "FOGGED" will cause unexplored
-areas to become explored. You must workaround this by using e.g. `SetFogStateRect`
+areas to become explored. You can workaround this by using e.g. `SetFogStateRect`
 after fog modifier creation.
 */
 native CreateFogModifierRadiusLoc takes player forWhichPlayer, fogstate whichState, location center, real radius, boolean useSharedVision, boolean afterUnits returns fogmodifier
@@ -203,6 +214,6 @@ native FogModifierStart takes fogmodifier whichFogModifier returns nothing
 
 /**
 Disable the effect of the modifier. Once disabled the player's visibility
-will return to the regular global fog state.
+will return to player's regular fog state.
 */
 native FogModifierStop takes fogmodifier whichFogModifier returns nothing

--- a/fog-of-war.j
+++ b/fog-of-war.j
@@ -1,23 +1,109 @@
 
 // Fog of War API
 
+/**
+Sets target player's fog of war data in the specified rectangle.
+
+The fog state is a reflection of what the player currently sees in game
+and on the minimap.
+
+@param forWhichPlayer Target player.
+@param whichState Change fog to this type.
+@param where Target rectangle area
+@param useSharedVision
+If true, apply new state to player and whoever player shares their vision.
+If false, apply only to player themself.
+*/
 native SetFogStateRect takes player forWhichPlayer, fogstate whichState, rect where, boolean useSharedVision returns nothing
 
+
+/**
+Sets target player's fog of war data in the specified circle area.
+
+The fog state is a reflection of what the player currently sees in game
+and on the minimap.
+
+@param forWhichPlayer Target player.
+@param whichState Change fog to this type.
+@param centerx X-coordinate of the circle center.
+@param centery Y-coordinate of the circle center.
+@param radius Circle's radius (from center to its edge)
+@param useSharedVision
+If true, apply new state to player and whoever player shares their vision.
+If false, apply only to player themself.
+*/
 native SetFogStateRadius takes player forWhichPlayer, fogstate whichState, real centerx, real centerY, real radius, boolean useSharedVision returns nothing
 
+/**
+Sets target player's fog of war data in the specified circle area.
+
+The fog state is a reflection of what the player currently sees in game
+and on the minimap.
+
+@param forWhichPlayer Target player.
+@param whichState Change fog to this type.
+@param center Location describing the center of the circle.
+@param radius Circle's radius (from center to its edge)
+@param useSharedVision
+If true, apply new state to player and whoever player shares their vision.
+If false, apply only to player themself.
+*/
 native SetFogStateRadiusLoc takes player forWhichPlayer, fogstate whichState, location center, real radius, boolean useSharedVision returns nothing
 
+
+/**
+Toggles global FOW masking of unexplored areas.
+
+An individual player's fog state is not modified, that means this toggle is fully
+reversible.
+
+@param enable
+True: unexplored areas are masked.
+
+False: unexplored areas are not masked (whether visible depends on `IsFogEnabled`).
+
+@note See: `IsFogMaskEnabled`, `FogEnable`
+*/
 native FogMaskEnable takes boolean enable returns nothing
 
+
+/**
+Returns whether global FOW masking is in effect.
+
+True: unexplored areas are globally masked.
+
+False: unexplored areas are not globally masked (whether visible depends on `IsFogEnabled`).
+*/
 native IsFogMaskEnabled takes nothing returns boolean
 
+
+/**
+Toggles global FOW fogging of explored yet not visible areas.
+
+An individual player's fog state is not modified, that means this toggle is fully
+reversible.
+
+True: explored areas are fogged if not in sight.
+
+False: explored areas remain permanently visible.
+*/
 native FogEnable takes boolean enable returns nothing
 
+
+/**
+Toggles global FOW fogging of explored yet not visible areas.
+
+True: explored areas are fogged if not in sight.
+
+False: explored areas remain permanently visible.
+*/
 native IsFogEnabled takes nothing returns boolean
 
 
 /**
-Creates an object that modifies the fog in a rect for a specific player.
+Creates an object that overrides the fog in a rect for a specific player.
+
+This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
 @param whichState
 Determines what type of fog the area is being modified to.
@@ -25,15 +111,23 @@ Determines what type of fog the area is being modified to.
 @param where The rect where the fog is
 
 @param useSharedVision
-Determines whether or not the fog modifier will be applied to allied players with shared vision.
+Apply modifier to target's allied players with shared vision?
 
 @param afterUnits
 Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
+
+@bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
+`FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
+enabled. "VISIBLE" will instantly become "FOGGED" and "FOGGED" will cause unexplored
+areas to become explored. You must workaround this by using e.g. `SetFogStateRect`
+after fog modifier creation.
 */
 native CreateFogModifierRect takes player forWhichPlayer, fogstate whichState, rect where, boolean useSharedVision, boolean afterUnits returns fogmodifier
 
 /**
-Creates an object that modifies the fog in a circular radius for a specific player.
+Creates an object that overrides the fog in a circular radius for a specific player.
+
+This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
 @param whichState
 Determines what type of fog the area is being modified to.
@@ -48,17 +142,25 @@ The y-coordinate where the fog modifier begins.
 Determines the extent that the fog travels (expanding from the coordinates ( centerx , centery )).
 
 @param useSharedVision
-Determines whether or not the fog modifier will be applied to allied players with shared vision.
+Apply modifier to target's allied players with shared vision?
 
 @param afterUnits
 Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
 
 @note You must use `FogModifierStart` to enable the fog modifier. 
+
+@bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
+`FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
+enabled. "VISIBLE" will instantly become "FOGGED" and "FOGGED" will cause unexplored
+areas to become explored. You must workaround this by using e.g. `SetFogStateRect`
+after fog modifier creation.
 */
 native CreateFogModifierRadius takes player forWhichPlayer, fogstate whichState, real centerx, real centerY, real radius, boolean useSharedVision, boolean afterUnits returns fogmodifier
 
 /**
-Creates an object that modifies the fog in a circular radius for a specific player.
+Creates an object that overrides the fog in a circular radius for a specific player.
+
+This creates a new object with a handle and must be removed to avoid leaks: `DestroyFogModifier`.
 
 @param whichState
 Determines what type of fog the area is being modified to.
@@ -70,17 +172,37 @@ The location where the fog modifier begins.
 Determines the extent that the fog travels (expanding from the location `center`).
 
 @param useSharedVision
-Determines whether or not the fog modifier will be applied to allied players with shared vision.
+Apply modifier to target's allied players with shared vision?
 
 @param afterUnits
 Will determine whether or not units in that area will be masked by the fog. If it is set to true and the fogstate is masked, it will hide all the units in the fog modifier's radius and mask the area. If set to false, it will only mask the areas that are not visible to the units.
 
 @note You must use `FogModifierStart` to enable the fog modifier. 
+
+@bug (v1.32.10) Just by creating a modifier of type `FOG_OF_WAR_FOGGED` or
+`FOG_OF_WAR_VISIBLE`, this will modify the player's global fog state before it is
+enabled. "VISIBLE" will instantly become "FOGGED" and "FOGGED" will cause unexplored
+areas to become explored. You must workaround this by using e.g. `SetFogStateRect`
+after fog modifier creation.
 */
 native CreateFogModifierRadiusLoc takes player forWhichPlayer, fogstate whichState, location center, real radius, boolean useSharedVision, boolean afterUnits returns fogmodifier
 
+
+/**
+Destroys the fog modifier object and removes its effect.
+*/
 native DestroyFogModifier takes fogmodifier whichFogModifier returns nothing
 
+
+/**
+Enable the effect of the modifier. While enabled, it will override the player's
+regular fog state.
+*/
 native FogModifierStart takes fogmodifier whichFogModifier returns nothing
 
+
+/**
+Disable the effect of the modifier. Once disabled the player's visibility
+will return to the regular global fog state.
+*/
 native FogModifierStop takes fogmodifier whichFogModifier returns nothing


### PR DESCRIPTION
There're a couple things I dont like about it, most importantly the terminology. I want to discuss this again and seriously.

This is called the Fog of War API. The FOW itself has 3 states (quoting my first draft here):

---

- `FOG_OF_WAR_MASKED` (1): Black mask, an unexplored map area.
   - If "Masked areas are partially visible" is enabled in Map Properties, unexplored areas are shown in dark grey. You can see the terrain, but no units.
   - If disabled, unexplored areas are black and not visible.
- `FOG_OF_WAR_FOGGED` (2): Haze, a previously explored
map area that is currently not visible.
   - You can see the terrain, but no units.
- `FOG_OF_WAR_VISIBLE` (4): A fully visible map area.
- Other (non-existent) fog types do nothing.

---

This seems fine until you begin dealing with individual function descriptions like FogMaskEnable, FogEnable. What I don't like about this is the ambiguous use of terms. On one hand this entire thing (API and concept) is called Fog of War. On the other hand, WC3 has the "mask vs fog" differentiation. In particular reusing "fog" seems to be a bad idea for clarity. It's not ideal to copy-paste this explanation everywhere.

I've asked in Hive Discord: GrapesOfWath would stay with these terms. Water would (probably) stay too but said this about my (over)simplification attempts (fair):

> not sure if the name should refer to the appearance
> you should call css classes after semantics, too

---

Options include:

1. (Current) Official: mask, fog ("explored"), visible. Good: no extra layers of terminology; Downside: full explanation must be read to be understood
2. Water's synonyms like: blurred, misty, veiled, faded, dimly, fuzzy, hazy, diffuse. Good: no clash on the word fog. Bad: uncommon words with little benefit.
3. Going by appearance: "black/blacked", "gray/greyed". Good: simple English, refers to in-game experience. Bad: gray remains ambiguous (masked is black/gray WE Option)
4. Middle ground: "hard fog" and "soft fog". Good: sort of understandable (yet masked black/gray still somewhat ambiguous). Bad: extra terminology, does not instantly make a connection like the literal "black & gray" (imo)