### PR TITLE
Describe Widget API

### DIFF
--- a/common.j
+++ b/common.j
@@ -20,7 +20,7 @@ type event              extends     agent  // a reference to an event registrati
 type player             extends     agent  // a single player reference
 
 /**
-A widget is an "interactive game object" with HP, inventory etc.
+A widget is an "interactive game object" with HP, possibly an inventory etc.
 
 Types `unit`, `destructable`, `item` extend from widget.
 Widget is the parent type and unit etc. are the descendant types (children).

--- a/common.j
+++ b/common.j
@@ -6,16 +6,43 @@
 @patch 1.24b
 */
 type agent			    extends     handle  // all reference counted objects
+
+
+/**
+Currently useless, although triggers return an event reference when you register
+a new trigger-event, there are no useful functions, and you cannot destroy
+an event object too.
+
+The only functions that take event are: `SaveTriggerEventHandle` and
+`SaveTriggerEventHandleBJ`.
+*/
 type event              extends     agent  // a reference to an event registration
 type player             extends     agent  // a single player reference
 
 /**
+A widget is an "interactive game object" with HP, inventory etc.
+
 Types `unit`, `destructable`, `item` extend from widget.
+Widget is the parent type and unit etc. are the descendant types (children).
 
-All API functions that accept widget, will also take any of the children types.
-However if doesn't work the other way around, then you need to explicitly cast the type by pushing it through a hashtable, "downcasting":
-Put the widget object in a hashtable and retrieve it as unit/destructable/item - needed since 1.24b, source: [The Helper Wiki](https://web.archive.org/web/20100118203210/http://wiki.thehelper.net/wc3/jass/common.j/Widget_API).
+Therefore all API functions that accept `widget` as a type, will also work with
+any of the children types.
 
+However if doesn't work the other way around, then you need to explicitly cast the type by pushing it through a hashtable, this is called "downcasting":
+
+1. Put the widget object in a hashtable
+2. Retrieve it as unit/destructable/item - needed since 1.24b,
+[source](https://web.archive.org/web/20100118203210/http://wiki.thehelper.net/wc3/jass/common.j/Widget_API)
+
+**Example (Lua)**:
+
+```{.lua}
+hasht = InitHashtable() -- for type-casting
+SaveWidgetHandle(hasht, 1, 1, widgetHandle) -- put as widget
+itemHandle = LoadItemHandle(hasht, 1, 1) -- retrieve as item
+```
+
+See `TriggerRegisterDeathEvent` for a full practical example.
 */
 type widget             extends     agent  // an interactive game object with life
 type unit               extends     widget  // a single unit reference
@@ -56,6 +83,10 @@ type playerevent        extends     eventid
 type playerunitevent    extends     eventid
 type unitevent          extends     eventid
 type limitop            extends     eventid
+
+/**
+Currently useless, there are no functions that take `widgetevent`.
+*/
 type widgetevent        extends     eventid
 type dialogevent        extends     eventid
 type unittype           extends     handle
@@ -1809,6 +1840,16 @@ TriggerRegisterGameEvent(trg_gameev, EVENT_GAME_BUILD_SUBMENU)
 
     constant unitevent EVENT_UNIT_LOADED                                = ConvertUnitEvent(88)
 
+/**
+Currently useless, there are no functions that take `widgetevent`.
+
+@note It was probably intended to be used in a similar way like
+`TriggerRegisterUnitEvent` and `TriggerRegisterFilterUnitEvent` that take
+a `unitevent`. It would have allowed to register an event for
+a specific widget (unit/item/destructable).
+
+@note See: `TriggerRegisterDeathEvent`
+*/
     constant widgetevent EVENT_WIDGET_DEATH                             = ConvertWidgetEvent(89)
 
     constant dialogevent EVENT_DIALOG_BUTTON_CLICK                      = ConvertDialogEvent(90)

--- a/common.j
+++ b/common.j
@@ -10,8 +10,8 @@ type agent			    extends     handle  // all reference counted objects
 
 /**
 Currently useless, although triggers return an event reference when you register
-a new trigger-event, there are no useful functions, and you cannot destroy
-an event object too.
+a new trigger-event, there are no useful functions.
+You cannot destroy an event object too (technically a leak).
 
 The only functions that take event are: `SaveTriggerEventHandle` and
 `SaveTriggerEventHandleBJ`.

--- a/destructable.j
+++ b/destructable.j
@@ -103,4 +103,9 @@ native SetDestructableOccluderHeight takes destructable d, real height returns n
 */
 native GetDestructableName takes destructable d returns string
 
+/**
+
+@note Can be used in `TriggerRegisterDeathEvent` if the dead widget is actually
+a destructable.
+*/
 constant native GetTriggerDestructable takes nothing returns destructable

--- a/player-based-event-api.j
+++ b/player-based-event-api.j
@@ -489,7 +489,61 @@ Returns the string that you registered for
 constant native GetEventPlayerChatStringMatched takes nothing returns string
 
 
+/**
+Makes the target trigger execute when specified widget dies.
+Returns registered event.
 
+Use `GetTriggerWidget` to retrieve the target. These work too if the widget
+is of the correct sub-type: `GetTriggerUnit`, `GetTriggerDestructable`.
+
+@note There's no "GetTriggerItem" so you have to downcast it from `widget` type.
+See example.
+
+@note **Example (Lua):** This event and trigger can be used to operate on
+widgets, units, destructables, items (with typecasting).
+
+```{.lua}
+-- Create necessary widgets
+u = CreateUnit(Player(0), FourCC("Hamg"), -30, 0, 90)
+d = CreateDestructable(FourCC("ZTg1"), 256, 0, 90, 1, 0)
+item = CreateItem(FourCC("war2"), 256, 384)
+
+-- This is our trigger action
+hasht = InitHashtable() -- for type-casting
+function widgetDied()
+	local w,u,d,i
+	w,u,d = GetTriggerWidget(),GetTriggerUnit(),GetTriggerDestructable()
+	if not u and not d then -- the widget is an item
+		-- Downcasting (explicit type casting from widget to a child type)
+		SaveWidgetHandle(hasht, 1, 1, w) -- put as widget
+		i = LoadItemHandle(hasht, 1, 1) -- retrieve as item
+	end
+	print("died object (widget, unit, destr, item):", w, u, d, i)
+	
+	local wXpos, uXpos, dXpos, iXpos
+	wXpos = GetWidgetX(w)
+	if u then uXpos = GetUnitX(u) end
+	if d then dXpos = GetDestructableX(d) end
+	if i then iXpos = GetItemX(i) end
+	print("died obj x pos (widget, unit, destr, item):", wXpos, uXpos, dXpos, iXpos)
+end
+
+-- Create and register widgets to this trigger
+trig = CreateTrigger()
+TriggerAddAction(trig, widgetDied)
+for k,widg in pairs({u,d,item}) do TriggerRegisterDeathEvent(trig, widg) end
+
+-- Kill widgets and observe what happens
+SetWidgetLife(u, 0)
+SetWidgetLife(d, 0)
+SetWidgetLife(item, 0)
+```
+
+@note You can use this with units, items, destructables. Explained in `widget`.
+
+@param whichTrigger Register death event to execute this trigger.
+@param whichWidget Trigger when this widget dies.
+*/
 native TriggerRegisterDeathEvent takes trigger whichTrigger, widget whichWidget returns event
 
 

--- a/unit-based-event-api.j
+++ b/unit-based-event-api.j
@@ -3,6 +3,9 @@
 /**
 Returns handle to unit which triggered the most recent event when called from
 within a trigger action function...returns null handle when used incorrectly
+
+@note Can be used in `TriggerRegisterDeathEvent` if the dead widget is actually
+a unit.
 */
 constant native GetTriggerUnit takes nothing returns unit
 

--- a/widget.j
+++ b/widget.j
@@ -1,25 +1,51 @@
 // Widget API
 
+/**
+Returns target's health points on succcess. Returns 0.0 if widget was removed or is null.
+
+@note See: `SetWidgetLife`.
+See `widget` for an explanation how this applies to units, destructables, items.
+
+@param whichWidget target widget
+*/
 native GetWidgetLife takes widget whichWidget returns real
 
+/**
+Sets target's health points.
+
+It is limited by target's maximum health points. A value of ≤0 kills the target.
+
+@note See: `GetWidgetLife`.
+See `widget` for an explanation how this applies to units, destructables, items.
+
+@param whichWidget target widget
+@param newLife set health points to this amount
+*/
 native SetWidgetLife takes widget whichWidget, real newLife returns nothing
 
 /**
 Returns X map coordinate of widget on success. Returns 0.0 if widget was removed or is null.
 
-Some other types extend from widget, you can use widget-related functions on these too.
+@note See: `GetWidgetY`.
+See `widget` for an explanation how this applies to units, destructables, items.
 
-@note See: `GetWidgetY`
+@param whichWidget target widget
 */
 native GetWidgetX takes widget whichWidget returns real
 
 /**
 Returns Y map coordinate of widget on success. Returns 0.0 if widget was removed or is null.
 
-Some other types extend from widget, you can use widget-related functions on these too.
+@note See: `GetWidgetX`.
+See `widget` for an explanation how this applies to units, destructables, items.
 
-@note See: `GetWidgetX`
+@param whichWidget target widget
 */
 native GetWidgetY takes widget whichWidget returns real
 
+/**
+Returns the target widget inside a trigger action. Otherwise returns null.
+
+@note Only works in triggers that operate on actual `widget` type, like `TriggerRegisterDeathEvent`.
+*/
 constant native GetTriggerWidget takes nothing returns widget

--- a/widget.j
+++ b/widget.j
@@ -44,7 +44,8 @@ See `widget` for an explanation how this applies to units, destructables, items.
 native GetWidgetY takes widget whichWidget returns real
 
 /**
-Returns the target widget inside a trigger action. Otherwise returns null.
+Returns the target widget (that caused the trigger-event) inside a trigger action.
+Otherwise returns null.
 
 @note Only works in triggers that operate on actual `widget` type, like `TriggerRegisterDeathEvent`.
 */


### PR DESCRIPTION
This line might struck your eye:

> A widget is an "interactive game object" with HP, **possibly an inventory** etc.

That's because the target in [UnitDropItemTarget](https://lep.duckdns.org/app/jassbot/doc/UnitDropItemTarget) is actually a widget :thinking: 