### PR TITLE
Describe Timer Dialog API

### DIFF
--- a/multiboard.j
+++ b/multiboard.j
@@ -146,10 +146,11 @@ it will override this color.
 @note You can use this to avoid using color tags and text manipulation in code.
 
 @param lb Target multiboard
-@param red 0-255 red color (clamped to 0-255)
-@param green 0-255 green color (clamped to 0-255)
-@param blue 0-255 blue color (clamped to 0-255)
-@param alpha (unused) 0-255 alpha color, please set to 255.
+@param red 0-255 red color (value mod 256)
+@param green 0-255 green color (value mod 256)
+@param blue 0-255 blue color (value mod 256)
+@param alpha (unused) 0-255 transparency, please set to 255.
+A value of 0 is complete transparency, while a value of 255 is complete opacity.
 
 @note See: `MultiboardSetItemValueColor`
 */
@@ -230,9 +231,9 @@ it will override this color.
 @note You can use this to avoid using color tags and text manipulation in code.
 
 @param lb Target multiboard
-@param red 0-255 red color (clamped to 0-255)
-@param green 0-255 green color (clamped to 0-255)
-@param blue 0-255 blue color (clamped to 0-255)
+@param red 0-255 red color (value mod 256)
+@param green 0-255 green color (value mod 256)
+@param blue 0-255 blue color (value mod 256)
 @param alpha (unused) 0-255 alpha color, please set to 255.
 
 @note See: `MultiboardSetItemValueColor`
@@ -328,9 +329,9 @@ it will override this color.
 
 @note You can use this to avoid using color tags and text manipulation in code.
 
-@param red 0-255 red color (clamped to 0-255)
-@param green 0-255 green color (clamped to 0-255)
-@param blue 0-255 blue color (clamped to 0-255)
+@param red 0-255 red color (value mod 256)
+@param green 0-255 green color (value mod 256)
+@param blue 0-255 blue color (value mod 256)
 @param alpha (unused) 0-255 alpha color, please set to 255.
 
 @note See: `MultiboardSetItemsValueColor`

--- a/timer-dialog.j
+++ b/timer-dialog.j
@@ -1,37 +1,171 @@
 // Timer Dialog API
 
+/**
+Creates a new timer dialog based on the underlying timer.
+It is hidden by default and has "Remaining" as title (localized).
+
+Timer dialog works as a visible countdown timer in the format: "Title hh:mm:ss".
+
+Since this creates an object and returns a handle, it must be freed when no longer needed
+with `DestroyTimerDialog`.
+
+@note (v1.32.10, Lua) If `t` is nil then the dialog is still created,
+but will never show any time.
+
+Alternatively, you can set the visible time with `TimerDialogSetRealTimeRemaining`.
+
+@param t connect the timer dialog to this timer, it'll always follow its
+"time remaining".
+*/
 native CreateTimerDialog                takes timer t returns timerdialog
 
+
+/**
+Destroys the timer dialog and frees the handle.
+
+This does not affect the timer you might have provided in `CreateTimerDialog`.
+
+@param whichDialog target dialog
+*/
 native DestroyTimerDialog               takes timerdialog whichDialog returns nothing
 
+
+/**
+Sets the shown dialog title. Replaces the default "Remaining" text.
+
+@note Depending on font and version, there's enough space to display
+14 full-width characters like "@" (at character). If the text is wider,
+it is shortened and an ellipsis "..." is shown at the end.
+
+@note See: `TimerDialogSetTitle`, `TimerDialogSetTitleColor`, `TimerDialogSetTimeColor`
+
+@param whichDialog target dialog
+@param title new title
+*/
 native TimerDialogSetTitle              takes timerdialog whichDialog, string title returns nothing
 
 /**
 Sets the timer-dialogs color.
 
+See: `TimerDialogSetTitle`, `TimerDialogSetTimeColor`
+
 @param whichDialog The timerdialog
-@param red An integer from 0-255 determining the amount of red color.
-@param green An integer from 0-255 determining the amount of green color.
-@param blue An integer from 0-255 determining the amount of blue color.
-@param alpha An integer from 0-255 determining the transparency. A value of 0 is complete transparency while a value of 255 is complete opacity.
+@param red 0-255 red color (value mod 256)
+@param green 0-255 green color (value mod 256)
+@param blue 0-255 blue color (value mod 256)
+@param alpha (unused) 0-255 transparency, please set to 255.
+A value of 0 is complete transparency, while a value of 255 is complete opacity.
 */
 native TimerDialogSetTitleColor         takes timerdialog whichDialog, integer red, integer green, integer blue, integer alpha returns nothing
 
 /**
 Sets the timer-dialogs time color.
 
+@note See: `TimerDialogSetTitleColor`
+
 @param whichDialog The timerdialog
-@param red An integer from 0-255 determining the amount of red color.
-@param green An integer from 0-255 determining the amount of green color.
-@param blue An integer from 0-255 determining the amount of blue color.
-@param alpha An integer from 0-255 determining the transparency. A value of 0 is complete transparency while a value of 255 is complete opacity.
+@param red 0-255 red color (value mod 256)
+@param green 0-255 green color (value mod 256)
+@param blue 0-255 blue color (value mod 256)
+@param alpha (unused) 0-255 transparency, please set to 255.
+A value of 0 is complete transparency, while a value of 255 is complete opacity.
 */
 native TimerDialogSetTimeColor          takes timerdialog whichDialog, integer red, integer green, integer blue, integer alpha returns nothing
 
+
+/**
+Set a new multiplier for the shown time remaining. Default is `1.0`.
+
+The multiplier factor is applied literally to the displayed time:
+`timerTimeRemainingSec * speedMultFactor`.
+
+@note It does not affect the underlying timer `t` from `CreateTimerDialog`.
+If you set the speed too high, the display will not become smoother as
+it updates roughly 2-3 times per second.
+
+@param whichDialog target dialog to modify the speed of
+@param speedMultFactor new multiplicator factor
+
+For factor `2.0` the displayed time will appear twice as fast (200% speed).
+
+For factor `0.5` the displayed time will appear half as fast (50% speed).
+
+Factor `0.0` will always display `00:00:00`.
+*/
 native TimerDialogSetSpeed              takes timerdialog whichDialog, real speedMultFactor returns nothing
 
+
+/**
+Show/hide the dialog for all players.
+
+A timer dialog is displayed above a multiboard in the top-right corner.
+
+@note Multiple timer dialogues stack from right to left, for example:
+"Timer dialog 2  12:34:56" "Timer dialog 1  02:10:42".
+
+@note If the timer has not been started yet, it will not show any time:
+"Remaining ".
+
+@note A dialog display can be toggled per-player by using it inside a
+`GetLocalPlayer` condition.
+
+@bug (v1.32.10) The second timerdialog's width and position is calculated and
+displayed incorrectly in ultra-wide mode (beyond 1800x920, 1.95 ratio).
+
+@bug (v1.32.10) If you toggle visibility of one dialog but not the other
+in a single frame, the first dialog will appear below the second one.
+
+```{.lua}
+	tdialog = CreateTimerDialog(CreateTimer())
+	TimerDialogSetTitle(tdialog, "Timer1 Dialog __ 1")
+	TimerDialogDisplay(tdialog, true)
+	tdialog2 = CreateTimerDialog(CreateTimer())
+	TimerDialogSetTitle(tdialog2, "Timer2 Dialog")
+	TimerDialogDisplay(tdialog2, true)
+	-- Correct up to this point.
+	-- This is buggy:
+	TimerDialogDisplay(tdialog, false)
+	TimerDialogDisplay(tdialog2, true)
+	TimerDialogDisplay(tdialog, true)
+	-- Now tdialog will appear beneath tdialog2.
+```
+
+**Workarounds:**
+
+1. Hide *every* dialog, then show those that you need.
+2. Introduce a sleep-wait before turning dialog display on.
+
+@note See: `IsTimerDialogDisplayed`
+
+@param whichDialog target dialog
+@param display `true` to show, `false` to hide
+*/
 native TimerDialogDisplay               takes timerdialog whichDialog, boolean display returns nothing
 
+
+/**
+Returns `true` if the dialog is shown, `false` if it is hidden.
+
+@note See: `TimerDialogDisplay`
+
+@param whichDialog check visibility of this timer dialog
+*/
 native IsTimerDialogDisplayed           takes timerdialog whichDialog returns boolean
 
+/**
+Sets the timer dialog countdown to specified time and decouples it from the
+provided timer in `CreateTimerDialog`.
+
+@note For example if the dialog was created with a periodic timer, it would
+reset the countdown like the timer when it reaches zero.
+
+Once you set a custom time with this function, it will no longer follow the
+timer. Once it reaches zero, it'll stay at zero.
+
+@note There's no way to retrieve the internal timer value or to have an event
+trigger.
+
+@param whichDialog target dialog
+@param timeRemaining new time in seconds
+*/
 native TimerDialogSetRealTimeRemaining  takes timerdialog whichDialog, real timeRemaining returns nothing

--- a/unit.j
+++ b/unit.j
@@ -239,10 +239,10 @@ The vertex color changes how the model is rendered. For example, setting all r,g
 To imagine the final result of changing vertex colors, it is helpful to think of individual RGB layers in a color image, if you disable the Red channel, only Green & Blue channels will be shown.
 
 @param whichUnit The unit to modify.
-@param red An integer from 0-255 determining the amount of red color.
-@param green An integer from 0-255 determining the amount of green color.
-@param blue An integer from 0-255 determining the amount of blue color.
-@param alpha An integer from 0-255 determining the opacity. A value of 255 is complete opacity (fully visible). A value of 0 is complete transparency; the model will be invisible, but you'll still see the shadow, HP bar etc.
+@param red visibility of red channel (clamped to 0-255)
+@param green visibility of green channel (clamped to 0-255)
+@param blue visibility of blue channel (clamped to 0-255)
+@param alpha opacity (clamped to 0-255). A value of 255 is total opacity (fully visible). A value of 0 is total transparency; the model will be invisible, but you'll still see the shadow, HP bar etc.
 
 @note Not to be confused with `SetUnitColor` which changes a unit's player accent color.
 */

--- a/visuals.j
+++ b/visuals.j
@@ -56,6 +56,10 @@ native ShowInterface                takes boolean flag, real fadeDuration return
 
 native PauseGame                    takes boolean flag returns nothing
 
+
+/**
+@note See: `AddIndicator` (it is a more generic version as it takes a `widget`)
+*/
 native UnitAddIndicator             takes unit whichUnit, integer red, integer green, integer blue, integer alpha returns nothing
 
 /**
@@ -69,6 +73,8 @@ this, you must edit the object editor field of the widget listed as "Art - Selec
 The indicator is shown below the unit selection.
 If the unit is currently selected, the blinking indicator will be practically
 hidden by the selection circle.
+
+@note See: `UnitAddIndicator` (functionally equivalent to this widget version)
 
 @param whichWidget The widget the indicator will be applied to.
 @param red 0-255 red color (value mod 256)

--- a/visuals.j
+++ b/visuals.j
@@ -72,7 +72,7 @@ this, you must edit the object editor field of the widget listed as "Art - Selec
 
 The indicator is shown below the unit selection.
 If the unit is currently selected, the blinking indicator will be practically
-hidden by the selection circle.
+hidden by the selection circle. For more see `SetImageType` description.
 
 @note See: `UnitAddIndicator` (functionally equivalent to this widget version)
 

--- a/visuals.j
+++ b/visuals.j
@@ -66,11 +66,16 @@ and is seen in `TransmissionFromUnitWithNameBJ`.
 @note The size of the indicator depends on a widget's selection size. To modify
 this, you must edit the object editor field of the widget listed as "Art - Selection Size".
 
+The indicator is shown below the unit selection.
+If the unit is currently selected, the blinking indicator will be practically
+hidden by the selection circle.
+
 @param whichWidget The widget the indicator will be applied to.
-@param red An integer from 0-255 determining the amount of red color in the indicator.
-@param green An integer from 0-255 determining the amount of green color in the indicator.
-@param blue An integer from 0-255 determining the amount of blue color in the indicator.
-@param alpha An integer from 0-255 determining the transparency of the indicator. A value of 0 is complete transparency while a value of 255 is complete opacity.
+@param red 0-255 red color (value mod 256)
+@param green 0-255 green color (value mod 256)
+@param blue 0-255 blue color (value mod 256)
+@param alpha 0-255 opacity (value mod 256). Determining the transparency
+of the indicator. `0` is total transparency, `255` is total opacity.
 */
 native AddIndicator                 takes widget whichWidget, integer red, integer green, integer blue, integer alpha returns nothing
 


### PR DESCRIPTION
From commit messages:

---

Testing code:
https://github.com/Luashine/wc3-test-maps/blob/1fd3cdaed228d5906a442bab27a8a9f4ce18ca55/README.md#timerdialog-api-tests

---

Previously I incorrectly described the r,g,b,a color values as if they
were clamped to (0,255). This is not the case. The input color value is
actually normalized with "value mod 256" or something similar, like an
integer division.

The result is that you get the magenta color for (-257, -256, -257) as
if you entered (255,0,255). The same applies to TimerDialogSetTitleColor
and probably other APIs of this kind.

Relatably, the float angles of unit facing are also normalized to be in
360 range.

Test code:

	mb = CreateMultiboard()
	-- yes, it's mod
	MultiboardSetTitleTextColor(mb, -257, -256, -257, 255)
	MultiboardSetTitleText(mb, "mboard title")
	MultiboardSetRowCount(mb, 1)
	MultiboardSetColumnCount(mb, 1)
	MultiboardSetItemsValue(mb, "ivalue")
	-- yes it's mod too
	MultiboardSetItemsValueColor(mb, -257, -256, -257, 255)
	MultiboardDisplay(mb, true)

---

Extra note for clarity about colors:

	-- How do colors behave?
	--> Answer: their value is normalized with modulo or similar
	TimerDialogSetTitleColor(tdialog, 0, 255, 0, 0) -- 100% green
	TimerDialogSetTitleColor(tdialog, 0, 382, 0, 0) -- 50% green
	TimerDialogSetTitleColor(tdialog, 0, 510, 0, 0) -- 100% green

	TimerDialogSetTitleColor(tdialog, 0, -1, 0, 0) -- 100%
	TimerDialogSetTitleColor(tdialog, 0, -240, 0, 0) -- very dark
	TimerDialogSetTitleColor(tdialog, 0, -255, 0, 0) -- black
	TimerDialogSetTitleColor(tdialog, 0, -256, 0, 0) -- black
	TimerDialogSetTitleColor(tdialog, 0, -257, 0, 0) -- 100%
	TimerDialogSetTitleColor(tdialog, -257, -257, -257, 0) -- 100%

I will probably check the rest of jassdoc where colors were used to fix those places.