### PR TITLE
Update effects.j

### DIFF
--- a/effects.j
+++ b/effects.j
@@ -303,7 +303,7 @@ Changes(set) the X, Y and Z (altitude) coordinate (Cartesian System) of the curr
 native BlzSetSpecialEffectPosition                 takes effect whichEffect, real x, real y, real z returns nothing
 
 /**
-Changes(set) the model height of the passed special effect. 
+Sets the effect's absolute Z position (height). This native is functionally identical to BlzSetSpecialEffectZ.
 
 @patch 1.29
 */


### PR DESCRIPTION
The description for BlzSetSpecialEffectHeight is wrong. I can't find any difference between it and BlzSetSpecialEffectZ.

I would guess BlzSetSpecialEffectHeight is supposed to take into account terrain height, but it doesn't.

The decompilation of the two are slightly different but they're both just different ways of applying Z height, with BlzSetSpecialEffectZ simply setting the Z field directly.

**BlzSetSpecialEffectHeight**
```cpp
*&a2.x = 0i64;
a2.z = 0.0;
v3 = GetEffectImageSprite(result);
SpriteUber__GetPosition(v3, &a2);
a2.z = *v7;
v5 = a2;
v4 = GetEffectImageSprite(v2);
result = SpriteUber__SetPosition(v4, *&v5.x, v5.z);
  ```

**BlzSetSpecialEffectZ**
```cpp
LODWORD(v9) = *(result + 148);
v4 = *(result + 152);
v10 = *z;
HIDWORD(v9) = v4;
v5 = (*(*result + 176))(result);
sub_800280(v5, &v9, 1);
v7 = v9;
v8 = v10;
v6 = GetEffectImageSprite(v3);
SpriteUber__SetPosition(v6, v7, v8);
```
    