### PR TITLE
Unit Facing, StartSoundEx, 12/24-player, GetHandleId, DisplayTextIII

### DIFF
--- a/common.ai
+++ b/common.ai
@@ -7,6 +7,10 @@ native DebugUnitID          takes string str, integer val               returns 
 native DisplayText          takes integer p, string str                 returns nothing
 native DisplayTextI         takes integer p, string str, integer val    returns nothing
 native DisplayTextII        takes integer p, string str, integer v1, integer v2 returns nothing
+
+/**
+Does nothing in release build v1.33.
+*/
 native DisplayTextIII       takes integer p, string str, integer v1, integer v2, integer v3 returns nothing
 native DoAiScriptDebug      takes nothing                               returns boolean
 

--- a/common.j
+++ b/common.j
@@ -6787,8 +6787,25 @@ Returns handle to unit.
 
 */
 native          CreateUnit              takes player id, integer unitid, real x, real y, real face returns unit
+
+
+/**
+@param face Unit facing in degrees.
+*/
 native          CreateUnitByName        takes player whichPlayer, string unitname, real x, real y, real face returns unit
+
+
+/**
+@param id The owner of the unit.
+@param unitid The rawcode of the unit.
+@param whichLocation The position of the unit.
+@param face Unit facing in degrees.
+*/
 native          CreateUnitAtLoc         takes player id, integer unitid, location whichLocation, real face returns unit
+
+/**
+@param face Unit facing in degrees.
+*/
 native          CreateUnitAtLocByName   takes player id, string unitname, location whichLocation, real face returns unit
 
 /**
@@ -6854,7 +6871,56 @@ canceling its orders use `SetUnitX`/`SetUnitY`.
 */
 native          SetUnitPosition     takes unit whichUnit, real newX, real newY returns nothing
 native          SetUnitPositionLoc  takes unit whichUnit, location whichLocation returns nothing
+
+
+/**
+Makes the unit slowly turn around on the spot to look at new direction.
+
+@param whichUnit Target unit.
+@param facingAngle Unit facing in degrees.
+
+* 0   = East
+* 90  = North
+* 180 = West
+* 270 = South
+* -90 = South (wraps around)
+*/
 native          SetUnitFacing       takes unit whichUnit, real facingAngle returns nothing
+
+
+/**
+Makes the unit slowly turn around on the spot to look at new direction,
+the turn speed can be modified with `duration`.
+
+@note Not affected by `GetUnitTurnSpeed`/`SetUnitTurnSpeed`.
+
+@bug For `duration == 0.5` the footman plays the running animation while turning.
+
+```{.lua}
+uf1 = CreateUnit(Player(0), FourCC("hfoo"), -128, 0, 90)
+uf2 = CreateUnit(Player(0), FourCC("hfoo"), 128, 0, 90)
+
+SetUnitFacing(uf1, -90)
+SetUnitFacingTimed(uf2, -90, 0.5)
+```
+
+@bug For `duration` values other than zero, the final angle is different
+than the requested angle, even when called repeatedly.
+
+```{.lua}
+SetUnitFacing(uf1, 90)
+SetUnitFacingTimed(uf2, 90, 1) --> final angle = 96.91184 (expected 90)
+```
+
+@param whichUnit Target unit.
+
+@param facingAngle New angle in degrees (direction), see: `SetUnitFacing`.
+
+@param duration
+Value >= 0 and < 1: same turn speed as `SetUnitFacing`.
+
+Values >= 1 seem to be applied like a multiplier, slowing down the turn speed.
+*/
 native          SetUnitFacingTimed  takes unit whichUnit, real facingAngle, real duration returns nothing
 native          SetUnitMoveSpeed    takes unit whichUnit, real newSpeed returns nothing
 native          SetUnitFlyHeight    takes unit whichUnit, real newHeight, real rate returns nothing

--- a/common.j
+++ b/common.j
@@ -1449,88 +1449,92 @@ constant native GetObjectName               takes integer objectId          retu
 /**
 Returns the maximum number of playable player slots regardless of map options.
 
-* Classic: 12
+* Classic: 12 (hardcoded as `bj_MAX_PLAYERS`)
 * Reforged: 24
 
-
-@note This is only affected by WorldEditor version specified in the map's war3map.w3i file. [Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
+@note This is only affected by WorldEditor version (>=6060) specified in the map's war3map.w3i file.
+[Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
 
 @note See: `bj_MAX_PLAYERS`, `GetBJMaxPlayerSlots`.
 
-@patch 1.29
-
+@patch 1.29.0.8803
 */
 constant native GetBJMaxPlayers             takes nothing returns integer
 
 /**
 Returns the zero-based ID of neutral victim player.
 
-* Classic = (13?)
-* Reforged: ID = 25
+* Classic: 13 (hardcoded as `bj_PLAYER_NEUTRAL_VICTIM`)
+* Reforged: 25
+
+@note This is only affected by WorldEditor version (>=6060) specified in the map's war3map.w3i file.
+[Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
 
 
 @note See: `bj_PLAYER_NEUTRAL_VICTIM`, `GetPlayerNeutralAggressive`, `GetBJPlayerNeutralExtra`, `GetPlayerNeutralPassive`.
 
-@patch 1.29
-
+@patch 1.29.0.8803
 */
 constant native GetBJPlayerNeutralVictim    takes nothing returns integer
 
 /**
 Returns the zero-based ID of neutral extra player.
 
-* Classic = (14?)
-* Reforged: ID = 26
+* Classic: 14 (hardcoded as `bj_PLAYER_NEUTRAL_EXTRA`)
+* Reforged: 26
+
+@note This is only affected by WorldEditor version (>=6060) specified in the map's war3map.w3i file.
+[Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
 
 
 @note See: `bj_PLAYER_NEUTRAL_EXTRA`, `GetPlayerNeutralAggressive`, `GetPlayerNeutralPassive`, `GetBJPlayerNeutralVictim`.
 
-@patch 1.29
-
+@patch 1.29.0.8803
 */
 constant native GetBJPlayerNeutralExtra     takes nothing returns integer
 
 /**
 Returns the maximum number of internal player slots regardless of map options.
 
-* Classic: (16?)
+* Classic: 16 (hardcoded as `bj_MAX_PLAYER_SLOTS`)
 * Reforged: 28
 
-
-@note This is only affected by WorldEditor version specified in the map's war3map.w3i file. [Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
+@note This is only affected by WorldEditor version (>=6060) specified in the map's war3map.w3i file.
+[Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
 
 @note See: `bj_MAX_PLAYER_SLOTS`, `GetBJMaxPlayers`.
 
-@patch 1.29
-
+@patch 1.29.0.8803
 */
 constant native GetBJMaxPlayerSlots         takes nothing returns integer
 
 /**
 Returns the zero-based ID of neutral passive player.
 
-* Classic = 15
-* Reforged: ID = 27
+* Classic: 15 (hardcoded as `PLAYER_NEUTRAL_PASSIVE`)
+* Reforged: 27
+
+@note This is only affected by WorldEditor version (>=6060) specified in the map's war3map.w3i file.
+[Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
 
 See: `PLAYER_NEUTRAL_PASSIVE`, `GetPlayerNeutralAggressive`, `GetBJPlayerNeutralExtra`, `GetBJPlayerNeutralVictim`.
 
-
-@patch 1.29
-
+@patch 1.29.0.8803
 */
 constant native GetPlayerNeutralPassive     takes nothing returns integer
 
 /**
 Returns the zero-based ID of neutral aggressive player.
 
-* Classic = 12
-* Reforged: ID = 24
+* Classic: 12 (hardcoded as `PLAYER_NEUTRAL_AGGRESSIVE`)
+* Reforged: 24
+
+@note This is only affected by WorldEditor version (>=6060) specified in the map's war3map.w3i file.
+[Further reading](https://www.hiveworkshop.com/threads/success-hybrid-12-24-player-map-backwards-compatible-1-24-1-28-5-1-31.339722/).
 
 See: `PLAYER_NEUTRAL_AGGRESSIVE`, `GetBJPlayerNeutralExtra`, `GetPlayerNeutralPassive`, `GetBJPlayerNeutralVictim`.
 
-
-@patch 1.29
-
+@patch 1.29.0.8803
 */
 constant native GetPlayerNeutralAggressive  takes nothing returns integer
 

--- a/common.j
+++ b/common.j
@@ -3935,14 +3935,27 @@ this will return the conversion of the valid part: `S2R(".123asd") == 0.123`.
 native S2R  takes string s returns real
 
 /**
-returns the internal index of the given handle.
+Returns the internal index of the given handle; returns 0 if `h` is `null`.
 
 **Example:** `GetHandleId(Player(0)) -> 1048584`
 
-@param h Handle
+@note Removing a game object does not automatically invalidate an allocated handle:
 
+```{.lua}
+uf = CreateUnit(Player(0), FourCC("hfoo"), -30, 0, 90)
+GetHandleId(uf) --> 1049016
+RemoveUnit(uf)
+GetHandleId(uf) --> 1049016
+uf = nil
+GetHandleId(uf) --> 0
+```
 
 @note Sometimes the handle ID may be different between clients.
+
+@note The handle index returned here is only a weak and not a conclusive indicator
+of leaking game objects. In other words, the number may be high without an actual leak.
+
+@param h Handle
 
 @patch 1.24b
 

--- a/common.j
+++ b/common.j
@@ -11851,6 +11851,8 @@ Starts playing a sound.
 @note An officially exported native in: 1.33.0 (checked v1.33.0.18897 PTR).
 Unofficially available in: 1.32 (not declared a native, but visible in Lua).
 
+@bug The `fadeIn` parameter does nothing (unused); thus equivalent to `StartSound`.
+
 @note The only difference to StartSound is the optional fadeIn (boolean).
 @patch 1.33
 


### PR DESCRIPTION
From commit messages:

`git log -n 5 --format=%s%n%b`

Add SetUnitFacing and SetUnitFacingTimed

string.j: GetHandleId returns a valid index for removed objects

sound.j: StartSoundEx, fadeIn is unused
Source: TriggerHappy/BogdanW3

common.j: Add exact WE Version for 12/24-p switch, fixes
Source: TriggerHappy; verified that 1.29.0.8803 has WE Version = 6060

common.ai: DisplayTextIII is a no-op
Source: BogdanW3 on Hive Discord

---

The rebasing wasn't fun, git has only shown the regular merge conflict ONCE. Else it wanted me to make out differences from entire split .j files... These are from November 2022

SetUnitFacingTimed should need more work it's like #31 the duration value is non-sense. Should I create an issue to track this?