### PR TITLE
Boolexpr API: Describe handle edge-cases, add See refs

### DIFF
--- a/common.j
+++ b/common.j
@@ -5131,47 +5131,60 @@ native ExecuteFunc          takes string funcName returns nothing
 //============================================================================
 
 /**
-Returns a new boolean expression that has the result of evaluating logical (expr1 AND expr2).
+Always returns a new boolean expression that has the result of evaluating logical (expr1 AND expr2).
 
 
 @note `boolexpr` extends from `agent` and must be explicitly destroyed with `DestroyBoolExpr` to prevent leaks.
 However, most functions from blizzard.j destroy passed boolexpr automatically.
 
+@note See: `Or`, `Not`, `Condition`, `Filter`, `DestroyBoolExpr`
 */
 native And              takes boolexpr operandA, boolexpr operandB returns boolexpr
 
 /**
-Returns a new boolean expression that has the result of evaluating logical (expr1 OR expr2).
+Always returns a new boolean expression that has the result of evaluating logical (expr1 OR expr2).
 
 
 @note `boolexpr` extends from `agent` and must be explicitly destroyed with `DestroyBoolExpr` to prevent leaks.
 However, most functions from blizzard.j destroy passed boolexpr automatically.
 
+@note See: `And`, `Not`, `Condition`, `Filter`, `DestroyBoolExpr`
 */
 native Or               takes boolexpr operandA, boolexpr operandB returns boolexpr
 
 /**
-Returns a new boolean expression that has the result of evaluating logical (NOT expr1).
-
+Always returns a new boolean expression that has the result of evaluating logical (NOT expr1).
 
 @note `boolexpr` extends from `agent` and must be explicitly destroyed with `DestroyBoolExpr` to prevent leaks.
 However, most functions from blizzard.j destroy passed boolexpr automatically.
 
+@note See: `And`, `Or`, `Condition`, `Filter`, `DestroyBoolExpr`
 */
 native Not              takes boolexpr operand returns boolexpr
 
 /**
-Returns a new conditionfunc that has the result of evaluating func(). func will receive no arguments and must return a boolean: true/false.
+Returns a new conditionfunc, when called by the game returns the result of evaluating func().
+func will receive no arguments and must return a boolean: true/false.
 
+@param func A function that returns boolean or `null`.
 
 @note 1.32.10, Lua: `conditionfunc` extends from `boolexpr`->`agent` and must be explicitly destroyed with `DestroyBoolExpr`/`DestroyCondition` to prevent leaks.
 However, most functions from blizzard.j destroy passed boolexpr automatically.
 
-@note (Old description) Do not destroy conditionfuncs created with `Condition` because this function
-does not create a new handle (`Condition(function foo) == Condition(function foo)`).
-In the best case it does nothing but in the worst case it affects some internals.
+@note **Lua:** Always returns a new handle unless the passed parameter is `nil`, in this case
+it MAY return the same handle depending on unknown conditions (consecutive calls are likely to reuse previous handle).
+
+**Jass:** Returns same handle when creating multiple filters for the same function:
+`Condition(function foo) == Condition(function foo)` ("foo" can be non-constant and constant).
+
+For this reason, do **not** destroy filterfuncs created with `Condition` in Jass,
+in the best case it does nothing but in the worst case it would affect some internals.
+
+This behavior is similar to `Condition`.
 
 @pure 
+
+@note See: `And`, `Or`, `Not`, `Condition`, `Filter`, `DestroyCondition`
 
 */
 native Condition        takes code func returns conditionfunc
@@ -5185,22 +5198,36 @@ However, most functions from blizzard.j destroy passed boolexpr automatically.
 
 @note Only call this on conditionfuncs created via `And`,`Or`,`Not`.
 
+@note See: `Condition`
+
 */
 native DestroyCondition takes conditionfunc c returns nothing
 
 /**
-Returns a new filterfunc that has the result of evaluating func().
+Returns a new filterfunc, when called by the game returns the result of evaluating func().
 func will receive no arguments and must return a boolean: true/false.
 
+
+@param func A filtering function that returns boolean or `null`.
 
 @note Lua, 1.32.10: `filterfunc` extends from `boolexpr`->`agent` and must be explicitly destroyed with `DestroyBoolExpr`/`DestroyFilter` to prevent leaks.
 However, most functions from blizzard.j destroy passed boolexpr automatically.
 
-@note (Old description)Do not destroy filterfuncs created with `Filter` because this function
-does not create a new handle (`Filter(function foo) == Filter(function foo)`).
-In the best case it does nothing but in the worst case it affects some internals.
+@note **Lua:** Always returns a new handle unless the passed parameter is `nil`, in this case
+it MAY return the same handle depending on unknown conditions (consecutive calls are likely to reuse previous handle).
+
+**Jass:** Returns same handle when creating multiple filters for the same function:
+`Filter(function foo) == Filter(function foo)` ("foo" can be non-constant and constant).
+
+For this reason, do **not** destroy filterfuncs created with `Filter` in Jass,
+in the best case it does nothing but in the worst case it would affect some internals.
+
+This behavior is similar to `Condition`.
 
 @pure 
+
+@note See: `And`, `Or`, `Not`, `Condition`, `DestroyFilter`;
+`GetFilterUnit`, `GetFilterItem`, `GetFilterPlayer`, `GetFilterDestructable`.
 
 */
 native Filter           takes code func returns filterfunc


### PR DESCRIPTION
Test code:

https://github.com/Luashine/wc3-test-maps/blob/3c52ea0994efa6f4f6e9c294ff616955f6a91686/Boolean-expression-API/README.md

In particular this paragraph rewritten:

(EDIT: dear `@note` I am sorry for pinging you again LOL)

> `@note` **Lua:** Always returns a new handle unless the passed parameter is `nil`, in this case
it MAY return the same handle depending on unknown conditions (consecutive calls are likely to reuse previous handle).

> **Jass:** Returns same handle when creating multiple filters for the same function:
`Filter(function foo) == Filter(function foo)` ("foo" can be non-constant and constant).

> For this reason, do **not** destroy filterfuncs created with `Filter` in Jass,
in the best case it does nothing but in the worst case it would affect some internals.

> This behavior is similar to `Condition`.

Lua: It's a surprise to me that the handling of handles is so inconsistent here. Maybe it's entirely related to GC but for unknown reasons it does not return the same handle when given a global function in Lua.