### PR TITLE
Rect API: Complete 16 -> 32 fix from PR #112

### DIFF
--- a/common.j
+++ b/common.j
@@ -4809,7 +4809,7 @@ The rectangle size and coordinates are limited to valid map coordinates, see
 
 
 @bug You can't create your own rectangle that would match the dimensions
-of `GetWorldBounds`. The maxX and maxY will be smaller by `16.0` than that of
+of `GetWorldBounds`. The maxX and maxY will be smaller by `32.0` than that of
 the world bounds.
 
 @note See: `Rect`, `SetRectFromLoc`, `MoveRectTo`, `MoveRectToLoc`.
@@ -4826,7 +4826,7 @@ Does nothing if either location is null or invalid.
 
 
 @bug You can't create your own rectangle that would match the dimensions
-of `GetWorldBounds`. The maxX and maxY will be smaller by `16.0` than that of
+of `GetWorldBounds`. The maxX and maxY will be smaller by `32.0` than that of
 the world bounds.
 
 @note See: `Rect`, `SetRect`, `MoveRectTo`, `MoveRectToLoc`.


### PR DESCRIPTION
That PR missed two more places there:
- SetRect
- SetRectFromLoc

https://github.com/lep/jassdoc/pull/112
Tests:
https://github.com/Luashine/wc3-test-maps/tree/5a2502b58bba21bc98cfd2513842fc79503fb8f8#rect--rectangle--region--location-code