### PR TITLE
Doc for Summon events and getters

### DIFF
--- a/common.j
+++ b/common.j
@@ -3461,6 +3461,14 @@ will return `""`. Use `TriggerRegisterPlayerChatEvent` instead.
 */
     constant playerunitevent EVENT_PLAYER_HERO_REVIVE_FINISH            = ConvertPlayerUnitEvent(46)
 /**
+Runs when something summons a new unit under specified player's control.
+
+Use `GetSummonedUnit` for the new unit and `GetSummoningUnit` for the spell caster.
+
+@note See: `EVENT_UNIT_SUMMON`
+
+@note `GetTriggerUnit` is equivalent to `GetSummonedUnit`.
+
 @patch 1.00
 */
     constant playerunitevent EVENT_PLAYER_UNIT_SUMMON                   = ConvertPlayerUnitEvent(47)
@@ -3642,6 +3650,17 @@ will return `""`. Use `TriggerRegisterPlayerChatEvent` instead.
     constant unitevent EVENT_UNIT_HERO_REVIVE_FINISH                    = ConvertUnitEvent(83)
                                                                         
 /**
+Runs when a unit summons another unit.
+
+Use `GetSummoningUnit` to get the spell caster.
+
+@note `GetSummonedUnit` returns null, probably because the event happens before
+the new unit is spawned.
+
+@note `GetTriggerUnit` is equivalent to `GetSummoningUnit`.
+
+@note See: `EVENT_PLAYER_UNIT_SUMMON`
+
 @patch 1.00
 */
     constant unitevent EVENT_UNIT_SUMMON                                = ConvertUnitEvent(84)
@@ -11570,18 +11589,23 @@ constant native GetDetectedUnit takes nothing returns unit
 // EVENT_PLAYER_UNIT_SUMMONED
 
 /**
-
+Returns the unit who casted the summoning spell.
 
 @event EVENT_PLAYER_UNIT_SUMMON
+@event EVENT_UNIT_SUMMON
+
+@note See: `GetSummonedUnit`.
 
 @patch 1.00
 */
 constant native GetSummoningUnit    takes nothing returns unit
 
 /**
-
+Returns the newly spawned unit.
 
 @event EVENT_PLAYER_UNIT_SUMMON
+
+@note See: `GetSummoningUnit`.
 
 @patch 1.00
 */

--- a/common.j
+++ b/common.j
@@ -11572,7 +11572,7 @@ constant native GetDetectedUnit takes nothing returns unit
 /**
 
 
-@event EVENT_PLAYER_UNIT_SUMMONED
+@event EVENT_PLAYER_UNIT_SUMMON
 
 @patch 1.00
 */
@@ -11581,7 +11581,7 @@ constant native GetSummoningUnit    takes nothing returns unit
 /**
 
 
-@event EVENT_PLAYER_UNIT_SUMMONED
+@event EVENT_PLAYER_UNIT_SUMMON
 
 @patch 1.00
 */


### PR DESCRIPTION
https://github.com/Luashine/wc3-test-maps/tree/master/GetSummonedUnit

Hey lep, I was not sure where to put the per-event descriptions for the getters. I chose and think it's better to put *what getters to use* under event constants, because there's only one event but many different getters. It's easier for editing due to the one-to-many relationship rather than many-to-many if I were to put the comment to each getter. But for usability like in IDE it'd be better to mirror relevant lines to the getter function descriptions, like when exporting or showing this.