### PR TITLE
common.j Add Info ALLIANCE_SHARED_CONTROL

### DIFF
--- a/common.j
+++ b/common.j
@@ -2047,14 +2047,16 @@ Stores the zero-based ID of neutral aggressive player.
 */
     constant alliancetype       ALLIANCE_SHARED_VISION          = ConvertAllianceType(5)
 /**
-allows to command units of an other player.
-commands that would spent the other players resources require ALLIANCE_SHARED_ADVANCED_CONTROL.
+Allows to command units of an other player.
+
+Commands that would spent the other players resources require  `ALLIANCE_SHARED_ADVANCED_CONTROL`.
 @patch 1.00
 */
     constant alliancetype       ALLIANCE_SHARED_CONTROL         = ConvertAllianceType(6)
 /**
-shows the allied Hero Icons below your heroes upto (7 - SetReservedLocalHeroButtons). When you have ALLIANCE_SHARED_ADVANCED_CONTROL without ALLIANCE_SHARED_CONTROL you have Hero Icons but cant command them. Pretty nice for an team rpg.
-Any adv shared shows the allied resources multiboard and allows to spent his resources.
+Shows the allied Hero Icons below your heroes up to (7 - `SetReservedLocalHeroButtons`). When you have `ALLIANCE_SHARED_ADVANCED_CONTROL` without `ALLIANCE_SHARED_CONTROL` then you will see hero icons on the left but can't command them.
+
+Any adv shared shows the allied resources multiboard and allows to spent the other player's resources.
 @patch 1.00
 */
     constant alliancetype       ALLIANCE_SHARED_ADVANCED_CONTROL= ConvertAllianceType(7)

--- a/common.j
+++ b/common.j
@@ -2056,7 +2056,9 @@ Commands that would spent the other players resources require  `ALLIANCE_SHARED_
 /**
 Shows the allied Hero Icons below your heroes up to (7 - `SetReservedLocalHeroButtons`). When you have `ALLIANCE_SHARED_ADVANCED_CONTROL` without `ALLIANCE_SHARED_CONTROL` then you will see hero icons on the left but can't command them.
 
-Any adv shared shows the allied resources multiboard and allows to spent the other player's resources.
+Shows the allied resources multiboard.
+
+Allows to spent the other player's resources.
 @patch 1.00
 */
     constant alliancetype       ALLIANCE_SHARED_ADVANCED_CONTROL= ConvertAllianceType(7)

--- a/common.j
+++ b/common.j
@@ -2047,10 +2047,14 @@ Stores the zero-based ID of neutral aggressive player.
 */
     constant alliancetype       ALLIANCE_SHARED_VISION          = ConvertAllianceType(5)
 /**
+allows to command units of an other player.
+commands that would spent the other players resources require ALLIANCE_SHARED_ADVANCED_CONTROL.
 @patch 1.00
 */
     constant alliancetype       ALLIANCE_SHARED_CONTROL         = ConvertAllianceType(6)
 /**
+shows the allied Hero Icons below your heroes upto (7 - SetReservedLocalHeroButtons). When you have ALLIANCE_SHARED_ADVANCED_CONTROL without ALLIANCE_SHARED_CONTROL you have Hero Icons but cant command them. Pretty nice for an team rpg.
+Any adv shared shows the allied resources multiboard and allows to spent his resources.
 @patch 1.00
 */
     constant alliancetype       ALLIANCE_SHARED_ADVANCED_CONTROL= ConvertAllianceType(7)


### PR DESCRIPTION
Adds some infos for ALLIANCE_SHARED_CONTROL & ALLIANCE_SHARED_ADVANCED_CONTROL.
Mostly about ally Hero Icons at the left side of screen.