### PR TITLE
Fixes #152 - GetUnitAbilityLevel and building abilities

### DIFF
--- a/common.j
+++ b/common.j
@@ -13901,8 +13901,9 @@ Returns the level of the ability for the unit.
 @param whichUnit Target unit.
 @param abilcode Abilities' raw code identifier.
 
-@note Building abilities {'ANbu','AHbu','AEbu','AObu','AUbu','AGbu'} are considered equal by the game.
+@note Building abilities {'ANbu','AHbu','AEbu','AObu','AUbu','AGbu'} are considered equivalent by the game (identical ability instance).
 If the unit has one of them, it has all of them (and vice-versa). Therefore a wisp with 'ANbu'==1 also has 'AHbu'==1.
+See: <https://github.com/lep/jassdoc/issues/152>
 
 @patch 1.13
 */
@@ -13915,7 +13916,7 @@ Returns the new ability level.
 @param whichUnit The unit with the ability.
 @param abilcode The four digit rawcode representation of the ability.
 
-@note It's not possible to reduce the level of a building ability like 'AHbu'. See `GetUnitAbilityLevel` and <https://github.com/lep/jassdoc/issues/152>.
+@note It's not possible to reduce the level of a building ability like 'AHbu'. See `GetUnitAbilityLevel`.
 
 @patch 1.17a
 */
@@ -14693,6 +14694,9 @@ Returns:
 cast (at the EVENT_PLAYER_UNIT_SPELL_EFFECT point), and while the caster is
 moving, will cause the caster to become unresponsive to new commands until
 they reach their ordered move point. 
+
+@note All different building ability codes like 'AHbu', 'ANbu' are considered equivalent. For example, removing 'AHbu' on a unit with only 'ANbu' would remove 'ANbu' instead. 
+See `GetUnitAbilityLevel`.
 
 @patch 1.00
 */
@@ -22441,6 +22445,9 @@ BlzUnitDisableAbility(u, FourCC"AHbu", false, true)
 @bug (1.32.10 confirmed) The game counts isDisabled and hideUI internally as integers(?) If you called 5 times "hideUI = true" to hide an icon then you'll need to multiple times "hideUI = false" to show it again. I do not exactly understand how it's counted.
 https://www.hiveworkshop.com/threads/blzunithideability-and-blzunitdisableability-dont-work.312477/
 
+@note All different building ability codes like 'AHbu', 'ANbu' are considered equivalent. For example, disabling 'AHbu' on a unit with only 'ANbu' would disable 'ANbu' instead. 
+See `GetUnitAbilityLevel`.
+
 @patch 1.29.2.9231
 
 */
@@ -23777,7 +23784,7 @@ native BlzSetSpecialEffectMatrixScale              takes effect whichEffect, rea
 native BlzResetSpecialEffectMatrix                 takes effect whichEffect returns nothing
 
 /**
-
+@note Returns the same ability instance for different building ability codes like 'AHbu', 'ANbu' etc. See `GetUnitAbilityLevel`.
 
 @patch 1.31.0.11889
 

--- a/common.j
+++ b/common.j
@@ -13901,6 +13901,8 @@ Returns the level of the ability for the unit.
 @param whichUnit Target unit.
 @param abilcode Abilities' raw code identifier.
 
+@note Building abilities {'ANbu','AHbu','AEbu','AObu','AUbu','AGbu'} are considered equal by the game.
+If the unit has one of them, it has all of them (and vice-versa). Therefore a wisp with 'ANbu'==1 also has 'AHbu'==1.
 
 @patch 1.13
 */
@@ -13913,6 +13915,7 @@ Returns the new ability level.
 @param whichUnit The unit with the ability.
 @param abilcode The four digit rawcode representation of the ability.
 
+@note It's not possible to reduce the level of a building ability like 'AHbu'. See `GetUnitAbilityLevel` and <https://github.com/lep/jassdoc/issues/152>.
 
 @patch 1.17a
 */
@@ -13954,6 +13957,9 @@ to set the level of an ability for an item on the unit, too. Since it's an attri
 when the item is dropped and picked up again. Via item abilities, a unit can have more than one instance of ability with the same ability id.
 This function will only set the level of the most recently obtained ability instance, then, which corresponds to the first ability instance found
 when using `BlzGetUnitAbilityByIndex` counting upwards.
+
+@bug It's possible to set a unit's building ability (like 'AHbu') to level 0 without an effect. See `GetUnitAbilityLevel`.
+
 @patch 1.17a
 */
 native          SetUnitAbilityLevel takes unit whichUnit, integer abilcode, integer level returns integer


### PR DESCRIPTION
Test code 1:

```lua
do 
	local units = {"hpea", "opeo", "uaco", "ewsp", "nmpe", "nhew", "nbee", "ogru"}
	local skills = {'ANbu','AHbu','AEbu','AObu','AUbu','AGbu'}

	function checkBuilderAbility(unitRawcode, skillCodes)
		local newUnit = CreateUnit(Player(0), FourCC(unitRawcode), 0, 0, 90)
		local outText = {"Unit(".. unitRawcode ..")"}
		for i, skill in ipairs(skillCodes) do
			table.insert(outText, 
				string.format("%4s", GetUnitAbilityLevel(newUnit, FourCC(skill)))
			)
		end
		
		print(table.concat(outText, ","))
	end
	
	local heading = string.format("%-12s %s", "Table:", table.concat(skills, ","))
	print(heading)
	for i = 1, #units do
		checkBuilderAbility(units[i], skills)
	end
	print("----")
end
```

Manual test code 2:

```lua
hpea = CreateUnit(Player(0), FourCC("hpea"), 0, 0, 90)

print(DecUnitAbilityLevel(hpea, FourCC("AHbu")))
print(IncUnitAbilityLevel(hpea, FourCC("AHbu")))
print(SetUnitAbilityLevel(hpea, FourCC("AHbu"), 0))

print(GetUnitAbilityLevel(hpea, FourCC("AHbu")))
print(GetUnitAbilityLevel(hpea, FourCC("AObu")))
```