### PR TITLE
SpecialEffect: clarify height reset for position changes

### DIFF
--- a/common.j
+++ b/common.j
@@ -22469,7 +22469,8 @@ Sets the effect's absolute X map position (east-west).
 @note Does not apply if the effect is attached to some model's attachment point (remains 0.0).
 
 @bug In 1.29-?? it will set the X coordinate, but reset the Y and Z to where it was spawned in.
-@bug In 1.36.2 it will set the X coordinate, but reset only Z to zero.
+@bug In 1.36.2 it will set the X coordinate,
+but reset Z to the height (relative to terrain and walkable elevating doodads) the effect was spawned at.
 @note See: `BlzSetSpecialEffectPosition`
 
 @patch 1.29.2.9231
@@ -22483,7 +22484,8 @@ Sets the effect's absolute Y map position (north/south).
 @note Does not apply if the effect is attached to some model's attachment point (remains 0.0).
 
 @bug In 1.29-?? it will set the Y coordinate, but reset the X and Z to where it was spawned in.
-@bug In 1.36.2 it will set the Y coordinate, but reset only Z to zero.
+@bug In 1.36.2 it will set the Y coordinate,
+but reset Z to the height (relative to terrain and walkable elevating doodads) the effect was spawned at.
 @note See: `BlzSetSpecialEffectPosition`
 
 @patch 1.29.2.9231
@@ -22519,7 +22521,8 @@ Sets the effect's absolute X and Y map position based on given location.
 
 @note Does not apply if the effect is attached to some model's attachment point (remains 0.0).
 
-@bug In 1.36.2 (and earlier?) it will set the X and Y coordinates, but reset Z to zero.
+@bug In 1.36.2 (and earlier?) it will set the X and Y coordinates,
+but reset Z to the height (relative to terrain and walkable elevating doodads) the effect was spawned at.
 @note See: `BlzSetSpecialEffectPosition`
 @patch 1.29.2.9231
 


### PR DESCRIPTION
Testing setup has got to be like that:

- need all possible terrain elevations:
   - flat 0, shallow water, deep water, hill
   - flat elevating doodad (platform) or doodad stairs (there's a slope) or doodad bridge

I suggest to start by spawning stuff on the slope/platforms becauase these give "nice" odd height values. Then set locations back and forth between other terrain heights. If you still get the spawning platform's odd value, then it was reset.

**Tip:** your testing map SHOULD start on either a +1 hill or -1 shallow water. Otherwise you'll get confused like I was that it resets to Z=0 (default flat surface).

Tested functions:

set height, set Z, set loc, set position (x,y,z), set special effect matrix, reset special effect matrix. Only the SetX, SetY, SetLoc functions needed corrections.

TLDR: there's no easy way to make a specialeffect adapt to a terrain elevation other than checking the terrain height yourself.