### PR TITLE
add a @bug about pausing a timer will clear its periodic flag

### DIFF
--- a/common.j
+++ b/common.j
@@ -10194,6 +10194,10 @@ native TimerGetRemaining    takes timer whichTimer returns real
 */
 native TimerGetTimeout      takes timer whichTimer returns real
 /**
+
+
+@bug The timer's periodic flag will be cleared.
+
 @patch 1.00
 */
 native PauseTimer           takes timer whichTimer returns nothing


### PR DESCRIPTION
a quick verification about this behavior:
![image](https://github.com/user-attachments/assets/802743ec-0a35-4dda-99c2-6cfd17dbde72)
![image](https://github.com/user-attachments/assets/ebee80ee-9173-4fb6-b89f-f7035211d82b)