### PR TITLE
Fix faulty event names. Small markdown syntax fix for parsers.

### DIFF
--- a/common.j
+++ b/common.j
@@ -14482,7 +14482,7 @@ constant native GetEventTargetUnit takes nothing returns unit
 // EVENT_UNIT_ATTACKED
 // Use GetAttacker from the Player Unit Event API Below...
 
-// EVENT_UNIT_RESCUED
+// EVENT_UNIT_RESCUEDED
 // Use GetRescuer from the Player Unit Event API Below...
 
 // EVENT_UNIT_CONSTRUCT_CANCEL
@@ -14491,7 +14491,7 @@ constant native GetEventTargetUnit takes nothing returns unit
 // See the Player Unit Construction Event API above for event info funcs
 
 // EVENT_UNIT_TRAIN_START
-// EVENT_UNIT_TRAIN_CANCEL
+// EVENT_UNIT_TRAIN_CANCELLED
 // EVENT_UNIT_TRAIN_FINISH
 
 // See the Player Unit Training Event API above for event info funcs


### PR DESCRIPTION
I'm not really sure whether it was really desirable for me to fix the faulty names in the comments of Blizzard themselves, but I did it anyway, as I presume those faulty Blizzard comments are what led to the faulty jassdoc to begin with.

The markdown syntax was killing off my markdig parser because it would get interpreted as an unclosed link and just voiding the entire rest of the paragraph (i.e. until after the double newline).