### PR TITLE
common.j: update v2.0.3 - UNIT_RF_FLY_MAX_HEIGHT 'ufmh'

### DIFF
--- a/common.j
+++ b/common.j
@@ -10021,6 +10021,11 @@ See `fogstate` for an explanation.
     constant unitrealfield UNIT_RF_FLY_HEIGHT                               = ConvertUnitRealField('ufyh')
 
 /**
+@patch 2.0.3.22904
+*/
+    constant unitrealfield UNIT_RF_FLY_MAX_HEIGHT                           = ConvertUnitRealField('ufmh')
+
+/**
 @patch 1.31.0.11889
 */
     constant unitrealfield UNIT_RF_TURN_RATE                                = ConvertUnitRealField('umvr')


### PR DESCRIPTION
There were multiple PTR step releases, so I had to track down the version number.

1. this change was announced in the first 2.0.3 PTR: <https://us.forums.blizzard.com/en/warcraft3/t/version-203-ptr-notes/36312> aka <https://us.forums.blizzard.com/en/warcraft3/t/version-203-ptr-notes/36314> --> corresponds to build "2.0.3.22904 - Test - June 23, 2025"
2. "week 2" <https://us.forums.blizzard.com/en/warcraft3/t/version-203-ptr-notes-week-2/36388>
3. "week 3" <https://us.forums.blizzard.com/en/warcraft3/t/version-203-ptr-notes-week-3/36490>

PS: no other file changes so far. I hadn't run a full jass-history dump though.