### PR TITLE
common.j Notes EnumItemsInRect & EnumDestructablesInRect

### DIFF
--- a/common.j
+++ b/common.j
@@ -15388,6 +15388,7 @@ native          IsItemIdSellable takes integer itemId returns boolean
 native          IsItemIdPawnable takes integer itemId returns boolean
 
 /**
+@note Includes hidden items on the Ground.
 @patch 1.07
 */
 native          EnumItemsInRect     takes rect r, boolexpr filter, code actionFunc returns nothing

--- a/common.j
+++ b/common.j
@@ -15042,6 +15042,7 @@ native          SetDestructableInvulnerable takes destructable d, boolean flag r
 native          IsDestructableInvulnerable  takes destructable d returns boolean
 
 /**
+@note Includes hidden destructables.
 @patch 1.00
 */
 native          EnumDestructablesInRect     takes rect r, boolexpr filter, code actionFunc returns nothing


### PR DESCRIPTION
EnumItemsInRect includes items that are set visible false and on ground, (no inventory items).
EnumDestructablesInRect includes hidden destructables.