### PR TITLE
ForceUIKey accepted keys and event limitations

### DIFF
--- a/common.j
+++ b/common.j
@@ -20239,7 +20239,9 @@ native PlayModelCinematic           takes string modelName returns nothing
 native PlayCinematic                takes string movieName returns nothing
 
 /**
-Emulates a key press within the game. Seems to only work with latin alphabet, only for printable ASCII characters.
+Emulates a key press within the game. Only accepts single Latin letters (`A`—`Z`, case-insensitive) and digits (`0`—`9`) as the key. Other characters are ignored.
+
+@note If you register both key down and key up events with `BlzTriggerRegisterPlayerKeyEvent`, only the key down event will fire for keys simulated with `ForceUIKey`.
 
 @note See `ForceUICancel` for limitations and bugs. Most importantly, the outcome is affected by local player's hotkey layout.
 


### PR DESCRIPTION
Based on internal code, the function only works with single Latin letters and digits. All other characters are ignored.
Relevant code from disassembly:
```cpp
if ( (string[0] = *v5, string[1] = 0, SStrUpper(string), v7 = string[0], string[0] >= 48) && v7 <= OSKEY_9
    || v7 >= OSKEY_A && v7 <= OSKEY_Z )
```

Additionally, only the key down event is triggered by `ForceUIKey`, while key up events do not. Example for testing:
```lua
-- Only Is key down: true will be printed
local testTrigger = CreateTrigger()
BlzTriggerRegisterPlayerKeyEvent(testTrigger, GetLocalPlayer(), OSKEY_1, 0, true)
BlzTriggerRegisterPlayerKeyEvent(testTrigger, GetLocalPlayer(), OSKEY_1, 0, false)

TriggerAddAction(testTrigger, function()
    print("Is key down: " .. tostring(BlzGetTriggerPlayerIsKeyDown()))
end)

TimerStart(CreateTimer(), 0.25, true, function()
    ForceUIKeyBJ(GetLocalPlayer(), "1")
end)
 ```       